### PR TITLE
Update

### DIFF
--- a/custom.d.ts
+++ b/custom.d.ts
@@ -8,7 +8,7 @@ declare module 'matrix-inverse' {
 	export = fn
 }
 
-interface LetteStyle {
+interface LetterStyle {
 	characters: string
 	fontSize?: number
 	fontName?: FontName
@@ -20,6 +20,7 @@ interface LetteStyle {
 	textStyleId?: string
 	fillStyleId?: string
 }
+type LineStyle = LetterStyle[]
 
 type FontStyleNames =
 	| 'fontSize'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@figma-plugin/helpers",
-	"version": "0.14.2",
+	"version": "0.14.3",
 	"description": "A collection of helper functions useful when creating Figma plugins",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@figma-plugin/helpers",
-  "version": "0.14.3",
+	"version": "0.14.3",
 	"description": "A collection of helper functions useful when creating Figma plugins",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@figma-plugin/helpers",
-	"version": "0.14.1",
+	"version": "0.14.2",
 	"description": "A collection of helper functions useful when creating Figma plugins",
 	"main": "dist/index.js",
 	"types": "dist/index.d.ts",


### PR DESCRIPTION
- splitTextStyleIntoLines: clarified.
- joinTextLinesStyles: you can now specify a newline character.
- applyTextStyleToTextNode: added the ability to skip font loading. Empty styles are ignored.
– Other fixes